### PR TITLE
Save tags in database outside of dialog fragment

### DIFF
--- a/app/src/main/java/com/example/pawsibilities/fragments/CreateTagDialogFragment.java
+++ b/app/src/main/java/com/example/pawsibilities/fragments/CreateTagDialogFragment.java
@@ -20,12 +20,15 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
+import android.widget.Toast;
 
 import com.example.pawsibilities.R;
 import com.example.pawsibilities.Tag;
 import com.example.pawsibilities.databinding.FragmentCreateTagBinding;
+import com.parse.ParseException;
 import com.parse.ParseFile;
 import com.parse.ParseGeoPoint;
+import com.parse.SaveCallback;
 
 import java.io.File;
 
@@ -97,7 +100,10 @@ public class CreateTagDialogFragment extends DialogFragment {
             @Override
             public void onClick(View view) {
                 tag.setName(binding.etName.getText().toString());
-                tag.setPhoto(new ParseFile(photoFile));
+                if (photoFile != null) {
+                    tag.setPhoto(new ParseFile(photoFile));
+
+                }
                 tag.setDirection((String) binding.spDirection.getSelectedItem());
                 sendBackResult();
             }

--- a/app/src/main/java/com/example/pawsibilities/fragments/CreateTagDialogFragment.java
+++ b/app/src/main/java/com/example/pawsibilities/fragments/CreateTagDialogFragment.java
@@ -102,7 +102,6 @@ public class CreateTagDialogFragment extends DialogFragment {
                 tag.setName(binding.etName.getText().toString());
                 if (photoFile != null) {
                     tag.setPhoto(new ParseFile(photoFile));
-
                 }
                 tag.setDirection((String) binding.spDirection.getSelectedItem());
                 sendBackResult();

--- a/app/src/main/java/com/example/pawsibilities/fragments/EditTagDialogFragment.java
+++ b/app/src/main/java/com/example/pawsibilities/fragments/EditTagDialogFragment.java
@@ -85,18 +85,7 @@ public class EditTagDialogFragment extends DialogFragment {
             @Override
             public void onClick(View view) {
                 tag.setActive(false);
-                tag.saveInBackground(new SaveCallback() {
-                    @Override
-                    public void done(ParseException e) {
-                        if (e != null) {
-                            Toast.makeText(getContext(), "Unable to update", Toast.LENGTH_SHORT).show();
-                            Log.e(TAG, "Unable to mark tag outdated", e);
-                        } else {
-                            Toast.makeText(getContext(), "Updated!", Toast.LENGTH_SHORT).show();
-                            dismiss();
-                        }
-                    }
-                });
+                sendBackResult();
             }
         });
 
@@ -105,20 +94,20 @@ public class EditTagDialogFragment extends DialogFragment {
             public void onClick(View view) {
                 tag.setName(binding.tvName.getText().toString());
                 tag.setDirection(binding.spDirection.getSelectedItem().toString());
-                tag.saveInBackground(new SaveCallback() {
-                    @Override
-                    public void done(ParseException e) {
-                        if (e != null) {
-                            Toast.makeText(getContext(), "Unable to update", Toast.LENGTH_SHORT).show();
-                            Log.e(TAG, "Unable to mark tag outdated", e);
-                        } else {
-                            Toast.makeText(getContext(), "Updated!", Toast.LENGTH_SHORT).show();
-                            dismiss();
-                        }
-                    }
-                });
+                sendBackResult();
             }
         });
+    }
+
+    public void sendBackResult() {
+        EditTagDialogFragment.EditTagDialogListener listener = (EditTagDialogFragment.EditTagDialogListener) getTargetFragment();
+        listener.onFinishEditDialog(tag);
+        dismiss();
+    }
+
+    // Defines the listener interface
+    public interface EditTagDialogListener {
+        void onFinishEditDialog(Tag newTag);
     }
 
     @Override


### PR DESCRIPTION
ParseObject.saveInBackground sometimes finishes after the dialog fragment has already been destroyed, so any Toasts defined in those fragments upon completion throw exceptions (now that the fragment and its context is null). Since I can't make the saveInBackground faster (depends on network connection) moving these toasts outside the fragments just prevents these exceptions.