### PR TITLE
Map focus

### DIFF
--- a/app/src/main/java/com/example/pawsibilities/fragments/MapsFragment.java
+++ b/app/src/main/java/com/example/pawsibilities/fragments/MapsFragment.java
@@ -55,7 +55,9 @@ import permissions.dispatcher.RuntimePermissions;
 import static com.google.android.gms.location.LocationServices.getFusedLocationProviderClient;
 
 @RuntimePermissions
-public class MapsFragment extends Fragment implements CreateTagDialogFragment.CreateTagDialogListener, EditTagDialogFragment.EditTagDialogListener, GoogleMap.OnMapLongClickListener {
+public class MapsFragment extends Fragment implements CreateTagDialogFragment.CreateTagDialogListener,
+        EditTagDialogFragment.EditTagDialogListener,
+        GoogleMap.OnMapLongClickListener {
 
     private static final String TAG = "MapsFragment";
     private FragmentMapsBinding mapsBinding;
@@ -125,6 +127,7 @@ public class MapsFragment extends Fragment implements CreateTagDialogFragment.Cr
             // Map is ready
             MapsFragmentPermissionsDispatcher.getMyLocationWithPermissionCheck(this);
             MapsFragmentPermissionsDispatcher.startLocationUpdatesWithPermissionCheck(this);
+            Log.i(TAG, "loadMap: " + mCurrentLocation);
 
             map.setOnMarkerClickListener(new GoogleMap.OnMarkerClickListener() {
                 @Override
@@ -153,7 +156,6 @@ public class MapsFragment extends Fragment implements CreateTagDialogFragment.Cr
 
                 tags.addAll(queried);
                 displayTags();
-
             }
         });
     }
@@ -258,6 +260,7 @@ public class MapsFragment extends Fragment implements CreateTagDialogFragment.Cr
                     public void onSuccess(Location location) {
                         if (location != null) {
                             mCurrentLocation = location;
+                            centerOnCurrentLocation();
                         }
                     }
                 })
@@ -275,7 +278,8 @@ public class MapsFragment extends Fragment implements CreateTagDialogFragment.Cr
             return;
         }
 
-        CameraUpdate center = CameraUpdateFactory.newLatLng(new LatLng(mCurrentLocation.getLatitude(), mCurrentLocation.getLongitude()));
+        CameraUpdate center = CameraUpdateFactory.newLatLng(new LatLng(mCurrentLocation.getLatitude(),
+                mCurrentLocation.getLongitude()));
         CameraUpdate zoom = CameraUpdateFactory.zoomTo(13);
         map.moveCamera(center);
         map.animateCamera(zoom);
@@ -296,7 +300,6 @@ public class MapsFragment extends Fragment implements CreateTagDialogFragment.Cr
         }
         MapsFragmentPermissionsDispatcher.startLocationUpdatesWithPermissionCheck(this);
     }
-
 
     // periodically checks for and updates the user's current location
     @NeedsPermission({Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION})
@@ -327,7 +330,6 @@ public class MapsFragment extends Fragment implements CreateTagDialogFragment.Cr
                     @Override
                     public void onLocationResult(LocationResult locationResult) {
                         mCurrentLocation = locationResult.getLastLocation();
-                        centerOnCurrentLocation();
                     }
                 }, Looper.myLooper());
     }

--- a/app/src/main/java/com/example/pawsibilities/fragments/MapsFragment.java
+++ b/app/src/main/java/com/example/pawsibilities/fragments/MapsFragment.java
@@ -68,7 +68,6 @@ public class MapsFragment extends Fragment implements CreateTagDialogFragment.Cr
     private LocationRequest mLocationRequest;
     private Location mCurrentLocation;
     private List<Tag> tags;
-    //private List<Marker> markers;
     private BitmapDescriptor defaultMarker;
 
     private final long UPDATE_INTERVAL_IN_SEC = 60000;  /* 60 secs */
@@ -96,7 +95,6 @@ public class MapsFragment extends Fragment implements CreateTagDialogFragment.Cr
         }
 
         tags = new ArrayList<>();
-        //markers = new ArrayList<>();
         defaultMarker  = BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_RED);
 
         mapFragment = ((SupportMapFragment) getChildFragmentManager().findFragmentById(R.id.map));
@@ -173,7 +171,6 @@ public class MapsFragment extends Fragment implements CreateTagDialogFragment.Cr
                     .icon(defaultMarker));
 
             mapMarker.setTag(t);
-            //markers.add(mapMarker);
         }
     }
 
@@ -235,7 +232,6 @@ public class MapsFragment extends Fragment implements CreateTagDialogFragment.Cr
         newMarker.setTag(newTag);
 
         tags.add(newTag);
-        //markers.add(newMarker);
     }
 
     @Override


### PR DESCRIPTION
Map doesn't refocus every few seconds and when map is expanded/shrunk, tags are discarded and only new tags within the map view are queried and put on map.

In the process of clearing and resetting markers there is a visible "blink" from the markers. There is potential to write a complicated algorithm that runs through tags/markers and just updates the changed ones rather than resetting everything. 